### PR TITLE
Add .txt files to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     #             "Topic :: Utilities",
                  ],
     package_data={
-        'cmocean': ['rgb/*.npy'],
+        'cmocean': ['rgb/*.npy', 'rgb/*.txt'],
     },    
     packages = ["cmocean"],
     # py_modules = cmocean_mod,


### PR DESCRIPTION
The `setup.py` script doesn't include the `.txt` files, so it fails to fully install with `python setup.py install`.

Alternatively, the `.npy` files are already included, so they could be used exclusively.