### PR TITLE
Fixed Freesurface-rgb.txt filename typo

### DIFF
--- a/cmocean/cm.py
+++ b/cmocean/cm.py
@@ -178,7 +178,7 @@ def make_vorticity_cmap():
 
 
 def make_freesurface_cmap():
-    rgb = np.loadtxt(os.path.join(datadir, 'FreeSurface-rgb.txt'))
+    rgb = np.loadtxt(os.path.join(datadir, 'Freesurface-rgb.txt'))
     cmap = tools.cmap(rgb, N=256)
     cmap.name = 'FreeSurface'
     cmap.long_name = 'Free Surface'


### PR DESCRIPTION
"FreeSurface" should have been "Freesurface". Now I'm able to
```
import cocean
```
successfully. Just that simple!