### PR TITLE
Fix file name for the Free Surface colour map.

### DIFF
--- a/cmocean/cm.py
+++ b/cmocean/cm.py
@@ -178,7 +178,7 @@ def make_vorticity_cmap():
 
 
 def make_freesurface_cmap():
-    rgb = np.loadtxt(os.path.join(datadir, 'FreeSurface-rgb.txt'))
+    rgb = np.loadtxt(os.path.join(datadir, 'Freesurface-rgb.txt'))
     cmap = tools.cmap(rgb, N=256)
     cmap.name = 'FreeSurface'
     cmap.long_name = 'Free Surface'


### PR DESCRIPTION
I had an error importing cmocean because the file name on disk differed from the specified file name in the code. I presume this is due to a case-insensitive file system being used somewhere for testing. I'm on Linux and the file system is case sensitive, so this broke the import.