### PR TITLE
Use absolute imports (for Python 3)

### DIFF
--- a/cmocean/__init__.py
+++ b/cmocean/__init__.py
@@ -6,9 +6,9 @@ See README.md for an overview on instructions.
 '''
 
 # from cmocean import *
-import cm
-import tools
-import plots
-import data
+from cmocean import cm
+from cmocean import tools
+from cmocean import plots
+from cmocean import data
 
 __authors__ = ['Kristen Thyng <kthyng@tamu.edu>']

--- a/cmocean/cm.py
+++ b/cmocean/cm.py
@@ -20,7 +20,7 @@ Used tool from http://bids.github.io/colormap/ to redo colormaps to be more perc
 '''
 
 # from matplotlib import cm, colors
-import tools
+from cmocean import tools
 import matplotlib
 # import plotting
 # import data

--- a/cmocean/plots.py
+++ b/cmocean/plots.py
@@ -2,11 +2,11 @@
 Plots with colormaps.
 '''
 
-import cm
+from cmocean import cm
 import matplotlib.pyplot as plt
 import numpy as np
 import matplotlib as mpl
-import tools
+from cmocean import tools
 # from skimage import color
 
 


### PR DESCRIPTION
Great package, thank you! But please use absolute imports, otherwise the package does not work with recent versions of Python. Note that implicit relative imports within packages, e.g., ``import plots``, are no longer allowed in Python 3.x.