### PR TITLE
Python 3 support and Travis-CI boilerplate.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: python
+
+env:
+    - CONDA="python=2.7"
+    - CONDA="python=3.4"
+    - CONDA="python=3.5"
+
+before_install:
+    - wget http://bit.ly/miniconda -O miniconda.sh
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$PATH"
+    - conda update --yes conda
+    - travis_retry conda create --yes -n TEST $CONDA --file requirements.txt
+    - source activate TEST
+    - travis_retry conda install --yes pytest
+
+script:
+    - python setup.py test

--- a/cmocean/__init__.py
+++ b/cmocean/__init__.py
@@ -5,10 +5,14 @@ oceanographic properties.
 See README.md for an overview on instructions.
 '''
 
+from __future__ import absolute_import
+
 # from cmocean import *
-from cmocean import cm
-from cmocean import tools
-from cmocean import plots
-from cmocean import data
+from . import cm, tools, plots, data
+
+__all__ = ['cm',
+           'tools',
+           'plots',
+           'data']
 
 __authors__ = ['Kristen Thyng <kthyng@tamu.edu>']

--- a/cmocean/cm.py
+++ b/cmocean/cm.py
@@ -19,14 +19,16 @@ Colormaps are available for:
 Used tool from http://bids.github.io/colormap/ to redo colormaps to be more perceptually correct.
 '''
 
+from __future__ import absolute_import
+
 # from matplotlib import cm, colors
-from cmocean import tools
 import matplotlib
 # import plotting
 # import data
 import numpy as np
 import os
 
+from . import tools
 
 # Location of rgb files
 datadir = os.path.join(os.path.split(__file__)[0], 'rgb')

--- a/cmocean/plots.py
+++ b/cmocean/plots.py
@@ -2,12 +2,15 @@
 Plots with colormaps.
 '''
 
-from cmocean import cm
+from __future__ import absolute_import
+
 import matplotlib.pyplot as plt
 import numpy as np
 import matplotlib as mpl
-from cmocean import tools
 # from skimage import color
+
+from . import cm
+from . import tools
 
 
 mpl.rcParams.update({'font.size': 14})

--- a/cmocean/tools.py
+++ b/cmocean/tools.py
@@ -51,9 +51,9 @@ def get_dict(cmap, N=256):
     r2 = rgb[:, 0]
 
     # Creating tuples
-    R = zip(x, r2, r3)
-    G = zip(x, g2, g3)
-    B = zip(x, b2, b3)
+    R = list(zip(x, r2, r3))
+    G = list(zip(x, g2, g3))
+    B = list(zip(x, b2, b3))
 
     # Creating dictionary
     k = ['red', 'green', 'blue']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+matplotlib

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,9 @@ setup.py for cmocean
 
 """
 # import shutil
+import sys
 from setuptools import setup # to support "develop" mode
+from setuptools.command.test import test as TestCommand
 # from numpy.distutils.core import setup, Extension
 
 # cmocean_mod = Extension(name = "cmocean",
@@ -14,6 +16,20 @@ from setuptools import setup # to support "develop" mode
 #                       )
 
 # print cmocean_mod
+
+class PyTest(TestCommand):
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.verbose = True
+
+    def run_tests(self):
+        import pytest
+        errno = pytest.main(self.test_args)
+        sys.exit(errno)
+
+with open('requirements.txt') as f:
+    require = f.readlines()
+install_requires = [r.strip() for r in require]
 
 setup(
     name = "cmocean",
@@ -30,11 +46,14 @@ setup(
                  ],
     package_data={
         'cmocean': ['rgb/*.txt'],
-    },    
+    },
     packages = ["cmocean"],
     # py_modules = cmocean_mod,
-    ext_package='cmocean', 
+    ext_package='cmocean',
     # ext_modules = [cmocean_mod],
     scripts = [],
     keywords = ['colormaps', 'oceanography', 'plotting', 'visualization'],
+    tests_require=['pytest'],
+    cmdclass=dict(test=PyTest),
+    install_requires=install_requires,
     )


### PR DESCRIPTION
This PR brings `cmocean` to Python 3 and adds some testing boilerplate to ensure I did not break anything.  You will need to enable Travis-CI for you repository.

Ping @rsignell-usgs.  If this gets merged and we get new release `cmocean` I will fix [our recipe](https://github.com/ioos/conda-recipes/pull/652) to build `cmocean` on Python 3.