### PR TITLE
Added MANIFEST.in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ before_install:
     - travis_retry conda create --yes -n TEST $CONDA --file requirements.txt
     - source activate TEST
     - travis_retry conda install --yes pytest
+    # GUI
+    - "export DISPLAY=:99.0"
+    - "sh -e /etc/init.d/xvfb start"
 
 script:
     - python setup.py test

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.rst
+include *.txt
+recursive-include cmocean *.txt
+recursive-include cmocean *.py

--- a/tests/test_cmocean.py
+++ b/tests/test_cmocean.py
@@ -12,17 +12,14 @@ def test_cmap_import():
 
     '''
 
-    import cmocean
-
-    # find all methods in cmocean
-    methods = dir(cmocean)
-
-    # loop through all methods in cmocean
-    for method in methods:
-
-        # see if method is a colormap
-        if type(eval('cmocean.' + method)) == matplotlib.colors.LinearSegmentedColormap:
+    from cmocean import cm
+    # Loop through all methods in cmocean.
+    for name, cmap in vars(cm).items():
+        # See if it is a colormap.
+        if isinstance(cmap, matplotlib.colors.LinearSegmentedColormap):
+            print(name)
             x = np.linspace(0, 10)
             X, _ = np.meshgrid(x, x)
             plt.figure()
-            plt.pcolor(X, cmap=eval('cmocean.' + method))
+            plt.pcolor(X, cmap=cmap)
+            plt.title(name)


### PR DESCRIPTION
In this PR:

- a lean MANIFEST.in that creates a source dist with the colormaps, code, and bare metadata (README.rst and LICENSE.txt)
- avoid the `eval` on the test

Note that the test is a simple: 'does this work' rather than a figure comparison test.  I am not sure if figure comparison is necessary here though.  But we can improve this a little bit.  They can fail silently.  We can add things like a list of the  expected colormaps.

Also, the colormaps are no longer in the main namespace as the previous test expected . (They where failing silently.)  Do you want them there?  Or the API `cmocean.cm.<cmap>` is OK?