### PR TITLE
add link to cmocean colormap available for Tableau

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -363,6 +363,7 @@ cmocean available elsewhere!
 * For `Paraview <https://github.com/kthyng/cmocean-paraview>`_, inspired by `Phillip Wolfram <https://github.com/pwolfram>`_.
 * In `Plotly <https://plot.ly/python/cmocean-colorscales/>`_
 * Chad Greene's `Antartic Mapping Tools <http://www.mathworks.com/matlabcentral/fileexchange/47638-antarctic-mapping-tools>`_ in Matlab uses cmocean
+* For `Tableau <https://www.tableau.com>`_ as a preferences file on `github <https://github.com/shaunwbell/cmocean_tableau>`_
 .. * In PyNcView: coming soon!
 
 Examples of beautiful visualizations:


### PR DESCRIPTION
Add link to Tableau preference file in github repository with cmocean based colormaps specified.