### PR TITLE
Update cm.py to register maps with matplotlib

### DIFF
--- a/cmocean/cm.py
+++ b/cmocean/cm.py
@@ -12,16 +12,9 @@ from __future__ import absolute_import
 
 import numpy as np
 import os
+from matplotlib import colors, cm
 
 from . import tools
-
-# If matplotlib is available, load it
-try:
-    import matplotlib.colors as mplc
-    import matplotlib.pyplot as plt
-    do_registry = True
-except:
-    do_registry = False
 
 # Location of rgb files
 datadir = os.path.join(os.path.split(__file__)[0], 'rgb')
@@ -41,18 +34,17 @@ for cmapname in cmapnames:
     cmap_d[cmapname].name = cmapname
     cmap_d[cmapname + '_r'] = tools.cmap(rgb[::-1, :], N=256)
     cmap_d[cmapname + '_r'].name = cmapname + '_r'
-    
-    # Register the cmap with matplotlib, if available
-    if do_registry:
-        rgb_with_alpha = np.zeros((rgb.shape[0],4))
-        rgb_with_alpha[:,:3] = rgb
-        rgb_with_alpha[:,3]  = 1.  #set alpha channel to 1
-        reg_map = mplc.ListedColormap(rgb_with_alpha, 'cmocean_' + cmapname, rgb.shape[0])
-        plt.register_cmap(cmap = reg_map)
-        
-        # Register the reversed map
-        reg_map_r = mplc.ListedColormap(rgb_with_alpha[::-1,:], 'cmocean_' + cmapname + '_r', rgb.shape[0])
-        plt.register_cmap(cmap = reg_map_r)
+
+    # Register the cmap with matplotlib
+    rgb_with_alpha = np.zeros((rgb.shape[0],4))
+    rgb_with_alpha[:,:3] = rgb
+    rgb_with_alpha[:,3]  = 1.  #set alpha channel to 1
+    reg_map = colors.ListedColormap(rgb_with_alpha, 'cmo.' + cmapname, rgb.shape[0])
+    cm.register_cmap(cmap = reg_map)
+
+    # Register the reversed map
+    reg_map_r = colors.ListedColormap(rgb_with_alpha[::-1,:], 'cmo.' + cmapname + '_r', rgb.shape[0])
+    cm.register_cmap(cmap = reg_map_r)
 
 # make colormaps available to call
 locals().update(cmap_d)

--- a/cmocean/cm.py
+++ b/cmocean/cm.py
@@ -15,6 +15,14 @@ import os
 
 from . import tools
 
+# If matplotlib is available, load it
+try:
+    import matplotlib.colors as mplc
+    import matplotlib.pyplot as plt
+    do_registry = True
+except:
+    do_registry = False
+
 # Location of rgb files
 datadir = os.path.join(os.path.split(__file__)[0], 'rgb')
 
@@ -33,6 +41,18 @@ for cmapname in cmapnames:
     cmap_d[cmapname].name = cmapname
     cmap_d[cmapname + '_r'] = tools.cmap(rgb[::-1, :], N=256)
     cmap_d[cmapname + '_r'].name = cmapname + '_r'
+    
+    # Register the cmap with matplotlib, if available
+    if do_registry:
+        rgb_with_alpha = np.zeros((rgb.shape[0],4))
+        rgb_with_alpha[:,:3] = rgb
+        rgb_with_alpha[:,3]  = 1.  #set alpha channel to 1
+        reg_map = mplc.ListedColormap(rgb_with_alpha, 'cmocean_' + cmapname, rgb.shape[0])
+        plt.register_cmap(cmap = reg_map)
+        
+        # Register the reversed map
+        reg_map_r = mplc.ListedColormap(rgb_with_alpha[::-1,:], 'cmocean_' + cmapname + '_r', rgb.shape[0])
+        plt.register_cmap(cmap = reg_map_r)
 
 # make colormaps available to call
 locals().update(cmap_d)


### PR DESCRIPTION
This commit checks if matplotlib is available and, if it is, registers the colour maps. 

Each map is available via 'cmocean_<map_name>', so that 'thermal' would be accessed, for example, by
plt.pcolormesh(x, y, z, cmap = 'cmocean_thermal').

Alpha channels were also explicitly added and set to 1 (for the matplotlib-registered maps only)

This merge will resolve issue #61 