### PR TITLE
Update README: add cmocean usage in Julia

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Besides Python, the cmocean colormaps are also available:
 
 * For [MATLAB](http://www.mathworks.com/matlabcentral/fileexchange/57773-cmocean-perceptually-uniform-colormaps) by [Chad Greene](http://www.chadagreene.com/)
 * For R: [Oce](http://dankelley.github.io/oce/) oceanographic analysis package by [Dan Kelley](http://www.dal.ca/faculty/science/oceanography/people/faculty/daniel-e-kelley.html) and [Clark Richards](http://clarkrichards.org/)
+* For Julia, included in [Plots.jl](https://github.com/JuliaPlots/Plots.jl) and [Makie.jl](https://github.com/JuliaPlots/Makie.jl)
 * For [Ocean Data Viewer](https://github.com/kthyng/cmocean-odv)
 * For Generic Mapping Tools (GMT)  at [cpt-city](http://soliton.vm.bytemark.co.uk/pub/cpt-city/cmocean/index.html) and on [github](https://github.com/kthyng/cmocean-gmt)
 * For [Paraview](https://github.com/kthyng/cmocean-paraview) inspired by [Phillip Wolfram](https://github.com/pwolfram)


### PR DESCRIPTION
Not sure how exactly it's done but cmocean color maps are included with Plots.jl and Makie.jl by default.