### PR TITLE
Prettify repo and update install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,21 @@
 language: python
 
 env:
-    - CONDA="python=2.7"
-    - CONDA="python=3.4"
-    - CONDA="python=3.5"
+  - CONDA="python=2.7"
+  - CONDA="python=3.4"
+  - CONDA="python=3.5"
 
 before_install:
-    - wget http://bit.ly/miniconda -O miniconda.sh
-    - bash miniconda.sh -b -p $HOME/miniconda
-    - export PATH="$HOME/miniconda/bin:$PATH"
-    - conda update --yes conda
-    - travis_retry conda create --yes -n TEST $CONDA --file requirements.txt
-    - source activate TEST
-    - travis_retry conda install --yes pytest
-    # GUI
-    - "export DISPLAY=:99.0"
-    - "sh -e /etc/init.d/xvfb start"
+  - wget http://bit.ly/miniconda -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - conda update --yes conda
+  - travis_retry conda create --yes -n TEST $CONDA --file requirements.txt
+  - source activate TEST
+  - travis_retry conda install --yes pytest
+  # GUI
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
 
 script:
-    - python setup.py test
+  - python setup.py test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-cmocean
-=======
+# cmocean
 
 Documentation available: [http://matplotlib.org/cmocean/](http://matplotlib.org/cmocean/).
 
@@ -9,28 +8,35 @@ link: [http://tos.org/oceanography/assets/docs/29-3_thyng.pdf](http://tos.org/oc
 
 Besides Python, the cmocean colormaps are also available:
 
-* For [MATLAB](http://www.mathworks.com/matlabcentral/fileexchange/57773-cmocean-perceptually-uniform-colormaps) by [Chad Greene](http://www.chadagreene.com/)
-* For [R cmocean](https://github.com/aitap/cmocean), which includes [ggplot2](ggplot2.tidyverse.org/) compatible functions. Also included in [Oce](http://dankelley.github.io/oce/): an oceanographic analysis package by [Dan Kelley](http://www.dal.ca/faculty/science/oceanography/people/faculty/daniel-e-kelley.html) and [Clark Richards](http://clarkrichards.org/).
-* For Julia, included in [Plots.jl](https://github.com/JuliaPlots/Plots.jl) and [Makie.jl](https://github.com/JuliaPlots/Makie.jl)
-* For [Ocean Data Viewer](https://github.com/kthyng/cmocean-odv)
-* For Generic Mapping Tools (GMT)  at [cpt-city](http://soliton.vm.bytemark.co.uk/pub/cpt-city/cmocean/index.html) and on [github](https://github.com/kthyng/cmocean-gmt)
-* For [Paraview](https://github.com/kthyng/cmocean-paraview) inspired by [Phillip Wolfram](https://github.com/pwolfram)
-* In [Plotly](https://plot.ly/python/cmocean-colorscales/)
-* Chad Greene's [Antarctic Mapping Tools](http://www.mathworks.com/matlabcentral/fileexchange/47638-antarctic-mapping-tools) in Matlab uses `cmocean`
-* For [Tableau](https://www.tableau.com) as a preferences file on [github](https://github.com/shaunwbell/cmocean_tableau)
-* For [ImageJ](https://imagej.nih.gov/ij/) as [LUTs](https://github.com/mikeperrins/cmocean-LUT-ImageJ)
-* For [ncview](http://meteora.ucsd.edu/~pierce/ncview_home_page.html) via [ncmaps](https://github.com/TomLav/ncmaps).
-* For [SeaDAS](https://github.com/gertvd-stanford/cmocean_seadas), and should work with BEAM/SNAP as well.
-
+- For [MATLAB](http://www.mathworks.com/matlabcentral/fileexchange/57773-cmocean-perceptually-uniform-colormaps) by [Chad Greene](http://www.chadagreene.com/)
+- For [R cmocean](https://github.com/aitap/cmocean), which includes [ggplot2](ggplot2.tidyverse.org/) compatible functions. Also included in [Oce](http://dankelley.github.io/oce/): an oceanographic analysis package by [Dan Kelley](http://www.dal.ca/faculty/science/oceanography/people/faculty/daniel-e-kelley.html) and [Clark Richards](http://clarkrichards.org/).
+- For Julia, included in [Plots.jl](https://github.com/JuliaPlots/Plots.jl) and [Makie.jl](https://github.com/JuliaPlots/Makie.jl)
+- For [Ocean Data Viewer](https://github.com/kthyng/cmocean-odv)
+- For Generic Mapping Tools (GMT) at [cpt-city](http://soliton.vm.bytemark.co.uk/pub/cpt-city/cmocean/index.html) and on [github](https://github.com/kthyng/cmocean-gmt)
+- For [Paraview](https://github.com/kthyng/cmocean-paraview) inspired by [Phillip Wolfram](https://github.com/pwolfram)
+- In [Plotly](https://plot.ly/python/cmocean-colorscales/)
+- Chad Greene's [Antarctic Mapping Tools](http://www.mathworks.com/matlabcentral/fileexchange/47638-antarctic-mapping-tools) in Matlab uses `cmocean`
+- For [Tableau](https://www.tableau.com) as a preferences file on [github](https://github.com/shaunwbell/cmocean_tableau)
+- For [ImageJ](https://imagej.nih.gov/ij/) as [LUTs](https://github.com/mikeperrins/cmocean-LUT-ImageJ)
+- For [ncview](http://meteora.ucsd.edu/~pierce/ncview_home_page.html) via [ncmaps](https://github.com/TomLav/ncmaps).
+- For [SeaDAS](https://github.com/gertvd-stanford/cmocean_seadas), and should work with BEAM/SNAP as well.
 
 To install:
-``pip install cmocean``
+
+```sh
+python -m pip install cmocean
+```
 
 To install with Anaconda:
-``conda install -c conda-forge cmocean``
+
+```sh
+conda install -c conda-forge cmocean
+```
 
 If you want to be able to use the `plots` submodule, you can instead install with:
 
-`pip install "cmocean[plots]"`
+```sh
+python -m pip install "cmocean[plots]"
+```
 
 which will also install `viscm` and `colorspacious`.


### PR DESCRIPTION
List of changes:
- prettified by `prettier -w .`
- update install instruction into code block for easy copy and paste in Markdown
- use `python -m pip` installation method, see https://snarky.ca/why-you-should-use-python-m-pip/