### PR TITLE
ENH: work around pending deprecation warnings in MPL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ setup(
     scripts = [],
     keywords = ['colormaps', 'oceanography', 'plotting', 'visualization'],
     setup_requires=['setuptools'],
-    install_requires=['matplotlib', 'numpy'],
+    install_requires=['matplotlib', 'numpy', 'packaging'],
     tests_require=['pytest'],
+    python_requires=">=3.8",
     extras_require=extras_require
     )


### PR DESCRIPTION
fix #83

notes:
- to maximize compatibility with all known versions of MPL, I'm adding `packaging` (which is extremely common, well distributed and maintained) as a dependency.
- ‡I'm also requiring Python 3.8 for `importlib.metadata`, but I can keep compatibility with older Python 3 version if desired, it's just a marginal ammount of additional work to leverage the backport `importlib_metadata`.
