### PR TITLE
numpy 2.0 compatibility np.unicode_

### DIFF
--- a/cmocean/tools.py
+++ b/cmocean/tools.py
@@ -8,10 +8,7 @@ import numpy as np
 import matplotlib as mpl
 
 
-if sys.version_info > (3,):
-    _string_types = (str, np.str_, np.unicode_)
-else:
-    _string_types = (basestring, np.str_, np.unicode_)
+_string_types = (str, np.str_)
 
 
 def print_colormaps(cmaps, N=256, returnrgb=True, savefiles=False):


### PR DESCRIPTION
I also assume that the check for python 2.0 is no longer needed since setup.py requires python >= 3.8.

See https://numpy.org/devdocs/numpy_2_0_migration_guide.html#main-namespace

Closes #98 