### PR TITLE
Avoid a deprecation warning from matplotlib 3.11 (dev)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Run Tests
         shell: bash -l {0}
         run: |
-          pytest --cov=./ --cov-report=xml
+          pytest -Werror --cov=./ --cov-report=xml
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/cmocean/cm.py
+++ b/cmocean/cm.py
@@ -53,11 +53,12 @@ for cmapname in cmapnames:
     rgb_with_alpha = np.zeros((rgb.shape[0],4))
     rgb_with_alpha[:,:3] = rgb
     rgb_with_alpha[:,3]  = 1.  #set alpha channel to 1
-    reg_map = colors.ListedColormap(rgb_with_alpha, N=rgb.shape[0])
+    assert len(rgb_with_alpha) == rgb.shape[0]
+    reg_map = colors.ListedColormap(rgb_with_alpha)
     _register_cmap(reg_map, name=f'cmo.{cmapname}')
 
     # Register the reversed map
-    reg_map_r = colors.ListedColormap(rgb_with_alpha[::-1,:], N=rgb.shape[0])
+    reg_map_r = colors.ListedColormap(rgb_with_alpha[::-1,:])
     _register_cmap(reg_map_r, name=f'cmo.{cmapname}_r')
 
     # Load inverted cmaps
@@ -71,9 +72,10 @@ for cmapname in cmapnames:
     rgb_with_alpha[:,3]  = 1.  #set alpha channel to 1
 
     # Register inverted cmaps
-    reg_map_i = colors.ListedColormap(rgb_with_alpha, N=rgb_i.shape[0])
+    assert len(rgb_with_alpha) == rgb_i.shape[0]
+    reg_map_i = colors.ListedColormap(rgb_with_alpha)
     _register_cmap(reg_map_i, name=f'cmo.{cmapname}_i')
-    reg_map_r_i = colors.ListedColormap(rgb_with_alpha[::-1,:], N=rgb_i.shape[0])
+    reg_map_r_i = colors.ListedColormap(rgb_with_alpha[::-1,:])
     _register_cmap(reg_map_r_i, name=f'cmo.{cmapname}_r_i')
 
     # order shouldn't matter


### PR DESCRIPTION
caught this while testing cmocean integration in another project whose CI install matplotlib nightlies and has `-Werror`
xref: https://github.com/matplotlib/matplotlib/pull/29135